### PR TITLE
Fix incorrect negation

### DIFF
--- a/Importer/AbstractImporter.php
+++ b/Importer/AbstractImporter.php
@@ -44,7 +44,7 @@ abstract class AbstractImporter implements ImporterInterface
      */
     protected function updateOrCreate(array $managedCurrencies, $code, $rate)
     {
-        if (!empty($managedCurrencies) && !in_array($code, $managedCurrencies)) {
+        if (!empty($managedCurrencies) && in_array($code, $managedCurrencies)) {
             foreach ($managedCurrencies as $currency) {
                 if ($code === $currency->getCode()) {
                     $currency->setExchangeRate($rate);


### PR DESCRIPTION
We have to check if is true that this code exist in the array to avoid duplicated entries.

Error found: Without this change if you run "sylius:currency:update ecb" more than one time, fatal error occurs because finOneBy (CurrencyConverter.php line 65) its returning more than one.
